### PR TITLE
Adding support for short adapter names using different namespace.

### DIFF
--- a/src/FilesystemRegistry.php
+++ b/src/FilesystemRegistry.php
@@ -159,6 +159,11 @@ class FilesystemRegistry
             return (new \ReflectionClass($leagueAdapter))->newInstanceArgs($vars);
         }
 
+	    $leagueAdapter = '\\League\\Flysystem\\' . $adapter . '\\' . $adapter . 'Adapter';
+	    if (class_exists($leagueAdapter)) {
+		    return (new \ReflectionClass($leagueAdapter))->newInstanceArgs($vars);
+	    }
+
         throw new \InvalidArgumentException('Unknown adapter');
     }
 }


### PR DESCRIPTION
e.g. League\Flysystem\Dropbox\DropboxAdapter