### PR TITLE
Fix to have MemoryAdapter working

### DIFF
--- a/src/FilesystemRegistry.php
+++ b/src/FilesystemRegistry.php
@@ -105,7 +105,7 @@ class FilesystemRegistry
     protected static function existsAndVarsCount($aliasConfigKey)
     {
         return Configure::check($aliasConfigKey . '.vars') &&
-            count(Configure::read($aliasConfigKey . '.vars')) > 0;
+            is_array(Configure::read($aliasConfigKey . '.vars'));
     }
 
     /**


### PR DESCRIPTION
MemoryAdapter does not have constructor. 
Instead of counting `vars` elements I propose just to check if `vars` exists as array, because empty `vars` is valid configuration in case of MemoryAdapter.