### PR TITLE
Client config defaults

### DIFF
--- a/src/Factory/AwsS3AdapterFactory.php
+++ b/src/Factory/AwsS3AdapterFactory.php
@@ -15,6 +15,10 @@ class AwsS3AdapterFactory
      */
     public static function client($config)
     {
+        $defaults = [
+            'path' => ''
+        ];
+        $config += $defaults;
         $client = new S3Client([
             'credentials' => [
                 'key' => $config['username'],


### PR DESCRIPTION
When S3 bucket connection has no directories $config['path'] is empty and PHP throws notice. We can add default region and version as well.